### PR TITLE
Add -renew option to renew group members (delete all existing members…

### DIFF
--- a/gadd2.ps1
+++ b/gadd2.ps1
@@ -1,3 +1,5 @@
+Param( [switch]$renew)
+
 $csvfile = Read-Host "CSVファイル名を入れてください"
 $emails = Import-Csv -Path $csvfile | Select-Object email
 
@@ -25,6 +27,18 @@ $group = Get-AzureADMSGroup -Filter "Mail eq `'$gmail`'"
 If ($false -eq $?) {
     Disconnect-AzureAD
     exit
+}
+
+
+If ($renew) {
+  $members = Get-AzureADGroupMember -All 1 -ObjectId $group.Id
+
+  Write-Host "以下のメンバーを削除します"
+  foreach ($d in $members){
+    Write-Host $d.DisplayName
+    Remove-AzureAdGroupMember -ObjectId $group.Id -MemberId $d.ObjectId
+  }
+  Write-Host "以下のアカウントを追加します"
 }
 
 foreach ($e in $emails) {


### PR DESCRIPTION
… and add members in the csv file). The program works as before if "-renew" is not used.
社工域の澤です。
-renew というオプションを追加しました。-renewをつける（「./gadd2.ps1 -renew」で実行する）と、現在グループにいるメンバーをすべて削除してから、指定のcsvファイルのアカウントをグループへ追加します。-renewオプションをつけなければ、現在の動作と変更ありません。こちらで検証した限りでは問題ありませんでしたが、問題なさそうであれば、反映いただけるとありがたいです。
登録者の名簿に変化があった際に、登録をやめた人を自動的に削除するのに使えるかと考えています。
git/githubを使ったことがないので、加筆のリクエストの仕方が良く分かっていないかもしれません。不明な点はお気軽にご連絡ください。
澤